### PR TITLE
Fix plugin reload callbacks

### DIFF
--- a/nana_2/CommandExecutor/cmd_main.py
+++ b/nana_2/CommandExecutor/cmd_main.py
@@ -14,6 +14,11 @@ class CommandExecutor:
         self.plugins = {}
         self._load_plugins()
 
+    def refresh_commands(self):
+        """Reload all plugin modules to refresh available commands."""
+        self.plugins = {}
+        self._load_plugins()
+
     def _load_plugins(self):
         """
         动态加载所有在 a/nana_2.0/plugins/ 文件夹里的插件。

--- a/nana_2/IntentDetector/ai_service/ai_service.py
+++ b/nana_2/IntentDetector/ai_service/ai_service.py
@@ -26,6 +26,10 @@ class AIService:
         # 调用和定义的方法名保持一致！
         self._load_main_prompts()
 
+    def rebuild_prompts(self):
+        """Reload main prompt configuration from disk."""
+        self._load_main_prompts()
+
     def _load_main_prompts(self):
         """只加载“主教科书”"""
         try:

--- a/nana_2/plugins/sample_plugin/__init__.py
+++ b/nana_2/plugins/sample_plugin/__init__.py
@@ -1,0 +1,15 @@
+from plugins.base_plugin import BasePlugin
+
+class SamplePlugin(BasePlugin):
+    def get_name(self):
+        return "sample_plugin"
+
+    def get_commands(self):
+        return ["do"]
+
+    def execute(self, command, args, controller):
+        pass
+
+
+def get_plugin():
+    return SamplePlugin()

--- a/nana_2/plugins/sample_plugin/sample_plugin_prompt.json
+++ b/nana_2/plugins/sample_plugin/sample_plugin_prompt.json
@@ -1,0 +1,4 @@
+{
+  "description": "Sample plugin for testing hot reload.",
+  "examples": []
+}

--- a/nana_2/tests/test_plugin_reload.py
+++ b/nana_2/tests/test_plugin_reload.py
@@ -1,0 +1,40 @@
+import unittest
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from core.plugin_system.plugin_manager import PluginManager
+
+class DummyAIService:
+    def __init__(self):
+        self.called = False
+    def rebuild_prompts(self):
+        self.called = True
+
+class DummyCommandExecutor:
+    def __init__(self):
+        self.called = False
+    def refresh_commands(self):
+        self.called = True
+
+class DummyController:
+    def __init__(self):
+        self.ai_service = DummyAIService()
+        self.command_executor = DummyCommandExecutor()
+
+class PluginReloadTests(unittest.TestCase):
+    def test_reload(self):
+        controller = DummyController()
+        manager = PluginManager(controller)
+        # ensure plugin loads
+        self.assertTrue(manager.load_plugin('sample_plugin'))
+        self.assertIn('sample_plugin', manager.plugins)
+        # reload
+        success, _ = manager.reload_plugin('sample_plugin')
+        self.assertTrue(success)
+        self.assertTrue(controller.ai_service.called)
+        self.assertTrue(controller.command_executor.called)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `rebuild_prompts` in `AIService`
- implement `refresh_commands` in `CommandExecutor`
- add a small sample plugin for tests
- provide tests for plugin hot reload

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b419bf778832cbe9af598cfd1b826