### PR TITLE
使用日志替换打印

### DIFF
--- a/nana_2/IntentDetector/CommandParser/parser.py
+++ b/nana_2/IntentDetector/CommandParser/parser.py
@@ -1,7 +1,8 @@
 # IntentDetector/CommandParser/parser_main.py
 
 from .Judge.validator import CommandValidator
-from .translate.formatter import  CommandFormatter
+from .translate.formatter import CommandFormatter
+from core.log.logger_config import logger
 
 
 class CommandParser:
@@ -13,7 +14,7 @@ class CommandParser:
     def __init__(self):
         self.validator = CommandValidator()
         self.formatter = CommandFormatter()
-        print("[解析器主管] 已初始化，下辖'质检部'和'翻译部'。")
+        logger.info("[解析器主管] 已初始化，下辖'质检部'和'翻译部'。")
 
     def parse(self, raw_command_from_ai: dict) -> dict:
         # 第一步：交给“质检部”进行审查
@@ -21,11 +22,11 @@ class CommandParser:
 
         if not is_valid:
             # 如果质检不通过，直接打回，并生成一个安全的回退指令
-            print(f"[解析器主管] 质检失败: {message}")
+            logger.info(f"[解析器主管] 质检失败: {message}")
             return self._create_fallback_command(message)
 
         # 第二步：如果质检通过，交给“翻译部”进行标准化
-        print(f"[解析器主管] 质检通过: {message}")
+        logger.info(f"[解析器主管] 质检通过: {message}")
         formatted_command = self.formatter.format(raw_command_from_ai)
 
         return formatted_command

--- a/nana_2/plugins/test_plugin/__init__.py
+++ b/nana_2/plugins/test_plugin/__init__.py
@@ -1,6 +1,7 @@
 # plugins/test_plugin/__init__.py
 
 from ..base_plugin import BasePlugin
+from core.log.logger_config import logger
 
 
 class TestPlugin(BasePlugin):
@@ -20,7 +21,7 @@ class TestPlugin(BasePlugin):
         """
         执行插件的核心逻辑。
         """
-        print(f"\n✅ [插件链路] 'test_plugin' 已被成功调用！执行命令: {command}, 参数: {args}\n")
+        logger.info(f"\n✅ [插件链路] 'test_plugin' 已被成功调用！执行命令: {command}, 参数: {args}\n")
 
         # 通过控制器，向GUI的消息队列发送一条“任务完成”的消息
         feedback_msg = ("测试插件", f"我被成功执行啦！收到的命令是'{command}'。", "nana_sender")


### PR DESCRIPTION
## Summary
- 引入 `core.log.logger_config` 的 `logger`
- 在 `CommandParser` 和 `test_plugin` 中使用 `logger.info`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b788e5e68832c9b0cce3c01cec33a