### PR TITLE
Add NoteTaker plugin

### DIFF
--- a/nana_2/plugins/note_taker/__init__.py
+++ b/nana_2/plugins/note_taker/__init__.py
@@ -1,0 +1,64 @@
+from plugins.base_plugin import BasePlugin
+from core.log.logger_config import logger
+from .notetaker_handle import (
+    ensure_notes_folder_exists,
+    create_note,
+    read_note,
+    delete_note,
+    list_notes,
+)
+from .notetaker_ui import open_note_editor, open_notes_window
+
+
+class NoteTakerPlugin(BasePlugin):
+    def get_name(self) -> str:
+        return "note_taker"
+
+    def get_commands(self) -> list[str]:
+        return ["create_note", "read_note", "delete_note", "list_notes"]
+
+    def on_load(self):
+        ensure_notes_folder_exists()
+
+    def execute(self, command: str, args: dict, controller) -> None:
+        title = args.get("title") if args else None
+        if command == "create_note":
+            if not title:
+                return
+            created = create_note(title)
+            msg = f"新建笔记 '{title}' 成功。" if created else f"笔记 '{title}' 已存在。"
+            controller.view.ui_queue.put(("APPEND_MESSAGE", ("Nana", msg, "nana_sender")))
+            content = "" if created else read_note(title)
+            open_note_editor(title, content, controller.view.master)
+        elif command == "read_note":
+            if not title:
+                return
+            try:
+                content = read_note(title)
+            except FileNotFoundError:
+                err = f"笔记 '{title}' 不存在。"
+                controller.view.ui_queue.put(("APPEND_MESSAGE", ("Nana酱", err, "error_sender")))
+                return
+            open_note_editor(title, content, controller.view.master)
+        elif command == "delete_note":
+            if not title:
+                return
+            try:
+                delete_note(title)
+                msg = f"已删除笔记 '{title}'。"
+                controller.view.ui_queue.put(("APPEND_MESSAGE", ("Nana", msg, "nana_sender")))
+            except FileNotFoundError:
+                err = f"笔记 '{title}' 不存在。"
+                controller.view.ui_queue.put(("APPEND_MESSAGE", ("Nana酱", err, "error_sender")))
+        elif command == "list_notes":
+            notes = list_notes()
+            if notes:
+                open_notes_window(notes, controller.view.master)
+            else:
+                controller.view.ui_queue.put(("APPEND_MESSAGE", ("Nana", "没有找到任何笔记。", "nana_sender")))
+        else:
+            logger.warning(f"未识别的命令: {command}")
+
+
+def get_plugin():
+    return NoteTakerPlugin()

--- a/nana_2/plugins/note_taker/note_taker_prompt.json
+++ b/nana_2/plugins/note_taker/note_taker_prompt.json
@@ -1,26 +1,93 @@
 {
-  "description": "【记事本插件】功能：可以创建、读取、删除文本笔记。",
+  "description": "记事本插件：可以创建、查找、删除以及列出笔记。",
   "examples": [
     {
-      "user": "帮我新建一个笔记，名字叫'会议纪要'",
+      "user": "帮我找一下上周的会议记录",
       "ai": {
-        "plugin": "note_taker",
-        "command": "create_note",
-        "args": {
-          "title": "会议纪要"
-        },
-        "response": "好的，正在为你创建名为'会议纪要'的新笔记。"
+        "intent": "search",
+        "entity": "上周的会议记录",
+        "response": "好的，正在为你查找关于“上周的会议记录”的笔记...",
+        "success_response": null
       }
     },
     {
-      "user": "我想看看'购物清单'这个笔记写了什么",
+      "user": "删掉那个叫做“购物清单”的笔记",
       "ai": {
-        "plugin": "note_taker",
-        "command": "read_note",
-        "args": {
-          "title": "购物清单"
-        },
-        "response": "收到，正在查找'购物清单'的内容。"
+        "intent": "delete",
+        "entity": "购物清单",
+        "response": "你确定要删除笔记“购物清单”吗？这个操作无法撤销哦。",
+        "success_response": "收到！笔记“购物清单”已经被我彻底删掉啦！"
+      }
+    },
+    {
+      "user": "创建一个名为“周末计划”的笔记",
+      "ai": {
+        "intent": "create",
+        "entity": "周末计划",
+        "response": "好的！为你创建了新笔记“周末计划”，并打开了编辑器哦！",
+        "success_response": null
+      }
+    },
+    {
+      "user": "你好吗？",
+      "ai": {
+        "intent": "chat",
+        "entity": null,
+        "response": "我很好，感谢关心！有什么可以为你服务的吗？",
+        "success_response": null
+      }
+    },
+    {
+      "user": "打开笔记列表",
+      "ai": {
+        "intent": "show_notes",
+        "entity": null,
+        "response": "好的，正在为你打开笔记列表窗口。",
+        "success_response": null
+      }
+    },
+    {
+      "user": "我有哪些笔记？",
+      "ai": {
+        "intent": "show_notes",
+        "entity": null,
+        "response": "好的，马上为你打开所有笔记的列表！",
+        "success_response": null
+      }
+    },
+    {
+      "conversation": [
+        {"role": "assistant", "content": "我找到了这个笔记：‘高分辨率’，你是想找这个吗？"},
+        {"role": "user", "content": "对的，打开它"}
+      ],
+      "ai": {
+        "intent": "confirm_action",
+        "target": "高分辨率",
+        "response": "收到！这就帮你打开笔记‘高分辨率’！",
+        "success_response": null
+      }
+    },
+    {
+      "conversation": [
+        {"role": "assistant", "content": "确定要删除笔记'会议纪要'吗？"},
+        {"role": "user", "content": "先别"}
+      ],
+      "ai": {
+        "intent": "deny_action",
+        "response": "好的，已取消操作。很高兴你改变了主意！",
+        "success_response": null
+      }
+    },
+    {
+      "conversation": [
+        {"role": "assistant", "content": "我找到了好几个相关的笔记：\n- 教程1\n- 教程2\n你指的是哪个呀？"},
+        {"role": "user", "content": "第一个"}
+      ],
+      "ai": {
+        "intent": "clarify_action",
+        "target": "教程1",
+        "response": "明白！正在为你打开笔记“教程1”。",
+        "success_response": null
       }
     }
   ]

--- a/nana_2/plugins/note_taker/notetaker_handle.py
+++ b/nana_2/plugins/note_taker/notetaker_handle.py
@@ -1,0 +1,39 @@
+import os
+from Gui.config import gui_config
+
+NOTES_FOLDER = "MyNotes"
+
+# Ensure notes directory exists
+NOTES_DIR = gui_config.NOTES_DIR
+
+def ensure_notes_folder_exists():
+    if not os.path.exists(NOTES_DIR):
+        os.makedirs(NOTES_DIR)
+
+def get_note_path(note_name: str) -> str:
+    return os.path.join(NOTES_DIR, f"{note_name}.txt")
+
+def list_notes() -> list[str]:
+    if not os.path.exists(NOTES_DIR):
+        return []
+    return sorted(
+        os.path.splitext(f)[0]
+        for f in os.listdir(NOTES_DIR)
+        if f.endswith(".txt")
+    )
+
+def create_note(note_name: str) -> bool:
+    ensure_notes_folder_exists()
+    note_path = get_note_path(note_name)
+    if os.path.exists(note_path):
+        return False
+    with open(note_path, "w", encoding="utf-8"):
+        pass
+    return True
+
+def delete_note(note_name: str) -> None:
+    os.remove(get_note_path(note_name))
+
+def read_note(note_name: str) -> str:
+    with open(get_note_path(note_name), "r", encoding="utf-8") as f:
+        return f.read()

--- a/nana_2/plugins/note_taker/notetaker_ui.py
+++ b/nana_2/plugins/note_taker/notetaker_ui.py
@@ -1,0 +1,79 @@
+import tkinter as tk
+from tkinter import scrolledtext, messagebox
+from .notetaker_handle import get_note_path, read_note
+from Gui.config import gui_config
+
+
+def open_note_editor(note_name: str, content: str = "", master_window=None):
+    editor_window = tk.Toplevel(master_window)
+    editor_window.title(f"{gui_config.NOTE_EDITOR_TITLE_PREFIX}{note_name}")
+    editor_window.config(bg=gui_config.BG_MAIN)
+
+    text_area = scrolledtext.ScrolledText(
+        editor_window,
+        wrap=tk.WORD,
+        width=80,
+        height=25,
+        font=(gui_config.GENERAL_FONT_FAMILY, gui_config.GENERAL_FONT_SIZE),
+        bg=gui_config.BG_INPUT,
+        fg=gui_config.FG_TEXT,
+        insertbackground=gui_config.CURSOR_COLOR,
+        bd=0,
+    )
+    text_area.insert(tk.END, content)
+    text_area.pack(padx=10, pady=10, fill="both", expand=True)
+
+    def save_note():
+        current_content = text_area.get(1.0, tk.END).strip()
+        try:
+            with open(get_note_path(note_name), "w", encoding="utf-8") as f:
+                f.write(current_content)
+            messagebox.showinfo(
+                gui_config.CONFIRM_SAVE_TITLE,
+                gui_config.CONFIRM_SAVE_MESSAGE.format(note_name=note_name),
+                parent=editor_window,
+            )
+        except Exception as e:
+            messagebox.showerror(
+                gui_config.ERROR_SAVE_TITLE,
+                gui_config.ERROR_SAVE_MESSAGE.format(e=e),
+                parent=editor_window,
+            )
+
+    save_button = tk.Button(
+        editor_window,
+        text=gui_config.SAVE_BUTTON_TEXT,
+        command=save_note,
+        bg=gui_config.BG_BUTTON,
+        fg=gui_config.FG_BUTTON,
+    )
+    save_button.pack(pady=5)
+
+
+def open_notes_window(notes: list[str], master_window=None):
+    win = tk.Toplevel(master_window)
+    win.title(gui_config.NOTES_WINDOW_TITLE)
+    win.config(bg=gui_config.BG_MAIN)
+
+    listbox = tk.Listbox(
+        win,
+        bg=gui_config.BG_LISTBOX,
+        fg=gui_config.FG_LISTBOX,
+        selectbackground=gui_config.SELECT_BG_LISTBOX,
+        selectforeground=gui_config.SELECT_FG_LISTBOX,
+    )
+    for n in notes:
+        listbox.insert(tk.END, n)
+    listbox.pack(fill="both", expand=True, padx=10, pady=10)
+
+    def on_open(event=None):
+        selection = listbox.curselection()
+        if selection:
+            note_name = listbox.get(selection[0])
+            try:
+                content = read_note(note_name)
+                open_note_editor(note_name, content, master_window)
+            except Exception as e:
+                messagebox.showerror("打开失败", f"无法打开笔记 '{note_name}': {e}")
+
+    listbox.bind("<Double-1>", on_open)


### PR DESCRIPTION
## Summary
- implement `NoteTakerPlugin` with create, read, delete and list commands
- add supporting note handling and UI modules
- expand plugin prompt with sample interactions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b88458e8c832ca78634432f20fc9e