### PR TITLE
Improve note selection workflow

### DIFF
--- a/nana_2/IntentDetector/ai_service/ai_service.py
+++ b/nana_2/IntentDetector/ai_service/ai_service.py
@@ -120,6 +120,8 @@ class AIService:
                     args = {}
                     if parsed_response.get("entity"):
                         args["title"] = parsed_response["entity"]
+                    elif parsed_response.get("target"):
+                        args["title"] = parsed_response["target"]
                     parsed_response = {
                         "plugin": plugin_name,
                         "command": command_name,

--- a/nana_2/plugins/note_taker/intent_map.json
+++ b/nana_2/plugins/note_taker/intent_map.json
@@ -5,5 +5,6 @@
   "show_notes": "list_notes",
 
   "search": "search_notes",
-  "search_notes": "search_notes"
+  "search_notes": "search_notes",
+  "clarify_action": "read_note"
 }

--- a/nana_2/tests/test_intent_registry.py
+++ b/nana_2/tests/test_intent_registry.py
@@ -27,6 +27,8 @@ class IntentRegistryTest(unittest.TestCase):
         manager.load_plugin('note_taker')
         self.assertIn('create', intent_registry)
         self.assertEqual(intent_registry['create'], ('note_taker', 'create_note'))
+        self.assertIn('clarify_action', intent_registry)
+        self.assertEqual(intent_registry['clarify_action'], ('note_taker', 'read_note'))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- map new intent `clarify_action` to `note_taker`'s `read_note`
- parse `target` field returned from AI to use as note title
- test that the new intent mapping loads correctly

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cd958edfc832c9df90926911a4781