### PR TITLE
Update note search mapping

### DIFF
--- a/nana_2/plugins/note_taker/intent_map.json
+++ b/nana_2/plugins/note_taker/intent_map.json
@@ -6,5 +6,6 @@
 
   "search": "search_notes",
   "search_notes": "search_notes",
+  "search_notes_by_keyword": "search_notes",
   "clarify_action": "read_note"
 }

--- a/nana_2/tests/test_intent_registry.py
+++ b/nana_2/tests/test_intent_registry.py
@@ -29,6 +29,11 @@ class IntentRegistryTest(unittest.TestCase):
         self.assertEqual(intent_registry['create'], ('note_taker', 'create_note'))
         self.assertIn('clarify_action', intent_registry)
         self.assertEqual(intent_registry['clarify_action'], ('note_taker', 'read_note'))
+        self.assertIn('search_notes_by_keyword', intent_registry)
+        self.assertEqual(
+            intent_registry['search_notes_by_keyword'],
+            ('note_taker', 'search_notes')
+        )
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- map `search_notes_by_keyword` intent to `search_notes`
- test that new mapping loads in `IntentRegistry`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e071a1f7c832ca90c25345d5b5833